### PR TITLE
Accept number in place of a data seq as dp count argument

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject differential-privacy-clj "0.2.0-SNAPSHOT"
+(defproject differential-privacy-clj "0.2.1-SNAPSHOT"
   :description "FIXME: write description"
   :url "http://github.com/OpenMined/differential-privacy-clj"
   :license {:name "Apache License"

--- a/src/differential_privacy_clj/core.clj
+++ b/src/differential_privacy_clj/core.clj
@@ -92,7 +92,7 @@
          args))
 
 
-(defn count [data-seq
+(defn count [data-seq-or-cnt
              & {:keys [max-partitions-contributed epsilon delta noise] :as kwargs}]
   (validate-keyword-arguments (keys kwargs)
                               count-required-kwargs)
@@ -103,7 +103,9 @@
                  delta (.delta delta)
                  noise (.noise noise))
                 .build)]
-    (.incrementBy cnt (size data-seq))
+    (.incrementBy cnt (if (number? data-seq-or-cnt)
+                        data-seq-or-cnt
+                        (size data-seq-or-cnt)))
     (.computeResult cnt)))
 
 


### PR DESCRIPTION
## Description

Currently the dp count function expects a data sequence as the first argument. This PR makes count function accept either a data sequence or a number (true count).

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [ ] My changes are covered by tests
