### PR TITLE
Add tests for bounded-sum, count and bounded-mean

### DIFF
--- a/test/differential_privacy_clj/core_test.clj
+++ b/test/differential_privacy_clj/core_test.clj
@@ -1,7 +1,42 @@
 (ns differential-privacy-clj.core-test
   (:require [clojure.test :refer :all]
-            [differential-privacy-clj.core :refer :all]))
+            [differential-privacy-clj.core :as dp]))
 
-(deftest a-test
-  (testing "FIXME, I fail."
-    (is (= 0 1))))
+
+;; default epsilon for testing
+(def e (Math/log 3))
+
+
+(deftest sum-test
+  (testing "bounded-sum"
+    (is (<= 5.2
+            (dp/bounded-sum [1.0 2.0 3.0]
+                            :epsilon (* 100 e)  ;; huge value for accuracy
+                            :lower 0.0
+                            :upper 10.0
+                            :max-partitions-contributed 1)
+            6.8))))
+
+(deftest count-test
+  (testing "count works with sequences"
+    (is (<= 96
+            (dp/count (repeat 100 :x)
+                      :epsilon e
+                      :max-partitions-contributed 1)
+            104)))
+  (testing "count works with numbers"
+    (is (<= 96
+            (dp/count 100
+                      :epsilon e
+                      :max-partitions-contributed 1)
+            104))))
+
+(deftest mean-test
+  (testing "bounded-mean"
+    (is (<= 4.5
+            (dp/bounded-mean (repeatedly 1000 #(rand 10.0))
+                             :epsilon e
+                             :lower 0 :upper 10
+                             :max-partitions-contributed 1
+                             :max-contributions-per-partition 1)
+            5.5))))


### PR DESCRIPTION
## Description

This PR adds some simple automated tests for bounded-sum, count and bounded-mean.
It doesn't set up a CI action because dependencies are still unavailable for download.

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
