### PR TITLE
Add protobuf types to deps; zsh compatible bazel command

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,10 +10,12 @@ jobs:
       - uses: actions/checkout@v1
       - name: Install maven
         run: sudo apt install maven
-      - name: Download the Java library
-        run: wget http://replomancer.net/OpenMined/libdifferentialprivacy-1.0.jar
+      - name: Download the Java library and protobuf jar
+        run: wget http://replomancer.net/OpenMined/libdifferentialprivacy-1.0.jar http://replomancer.net/OpenMined/libsummary-proto-speed.jar
       - name: Install the Java library to local Maven repo
         run: mvn install:install-file -Dfile=libdifferentialprivacy-1.0.jar -DgroupId=com.google.privacy.differentialprivacy -DartifactId=libdifferentialprivacy -Dversion=1.0 -Dpackaging=jar
+      - name: Install the protobuf jar to local Maven repo
+        run: mvn install:install-file -Dfile=libsummary-proto-speed.jar -DgroupId=com.google.differentialprivacy -DartifactId=libsummary-proto-speed -Dversion=1.0 -Dpackaging=jar
       - name: Install remaining dependencies
         run: lein deps
       - name: Check formatting

--- a/README.md
+++ b/README.md
@@ -16,13 +16,15 @@ Steps to build it locally:
 ```
 git clone https://github.com/google/differential-privacy.git
 cd differential-privacy/java/
-bazel build ...
+bazel build "..."
 ```
 
-3. Install `libdifferentialprivacy.jar` in your local Maven repository:
+3. Install `libdifferentialprivacy.jar` and `libsummary-proto-speed.jar` in your local Maven repository:
 
 ```
 mvn install:install-file -Dfile=bazel-bin/main/com/google/privacy/differentialprivacy/libdifferentialprivacy.jar -DgroupId=com.google.privacy.differentialprivacy -DartifactId=libdifferentialprivacy -Dversion=1.0 -Dpackaging=jar
+
+mvn install:install-file -Dfile=bazel-bin/external/com_google_differential_privacy/proto/libsummary-proto-speed.jar -DgroupId=com.google.differentialprivacy -DartifactId=libsummary-proto-speed -Dversion=1.0 -Dpackaging=jar
 ```
 
 4. Clone this repository and install the library:

--- a/project.clj
+++ b/project.clj
@@ -7,7 +7,8 @@
                  [com.google.protobuf/protobuf-java "3.11.4"]
                  [org.apache.commons/commons-math3 "3.6.1"]
                  [com.google.guava/guava "28.2-jre"]
-                 [com.google.privacy.differentialprivacy/libdifferentialprivacy "1.0"]]
+                 [com.google.privacy.differentialprivacy/libdifferentialprivacy "1.0"]
+                 [com.google.differentialprivacy/libsummary-proto-speed "1.0"]]
   :repl-options {:init-ns differential-privacy-clj.core}
 
   :profiles {:dev {:plugins [[lein-cljfmt "0.6.8"]


### PR DESCRIPTION
## Description

Adds missing protobuf types to dependencies, so that repl autocomplete starts working and Noise interface can be used (for testing).

Bazel command in README.md is now compatible with zsh.

CI updated accordingly.

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [ ] My changes are covered by tests
